### PR TITLE
Existing methods mirror native node api.

### DIFF
--- a/lib/node-functions.js
+++ b/lib/node-functions.js
@@ -1,0 +1,57 @@
+const fs = require('fs')
+const R = require('ramda')
+
+const fsMethodNames = [
+  'access',
+  'appendFile',
+  'chmod',
+  'chown',
+  'close',
+  'createReadStream',
+  'createWriteStream',
+  'exists',
+  'fchmod',
+  'fchown',
+  'fdatasync',
+  'fstat',
+  'fsync',
+  'ftruncate',
+  'futimes',
+  'lchmod',
+  'lchown',
+  'link',
+  'lstat',
+  'mkdir',
+  'mkdtemp',
+  'open',
+  'read',
+  'readdir',
+  'readFile',
+  'readlink',
+  'realpath',
+  'rename',
+  'rmdir',
+  'stat',
+  'symlink',
+  'truncate',
+  'unlink',
+  'unwatchFile',
+  'utimes',
+  'watch',
+  'watchFile',
+  'write',
+  'write',
+  'writeFile'
+]
+
+const fsMethodLengths = R.compose(
+  R.fromPairs,
+  R.map((methodName) => [
+    methodName,
+    fs[methodName].length - 1
+  ]),
+  R.filter((methodName) => !!fs[methodName])
+)(fsMethodNames)
+
+// Filter out functions not present in this version of node.
+exports.fs = fsMethodLengths

--- a/lib/node.js
+++ b/lib/node.js
@@ -2,6 +2,7 @@ const fs = require('fs')
 const io = require('./io').io
 const ioTask = require('./io').task
 const R = require('ramda')
+const fsMethodLengths = require('./node-functions').fs
 
 // # IO returning functions.
 // log :: String -> IO ()
@@ -37,33 +38,29 @@ exports.exit = function (code) {
   )
 }
 
-// argv :: () -> IO [Arg]
-exports.argv = function () {
-  return io(
-    (world) => world.process.argv
-  )
-}
+// argv :: IO [Arg]
+exports.argv = io(
+  (world) => world.process.argv
+)
 
-// readFile :: Object -> Path -> IO String
-exports.readFile = R.curry(function (options, path) {
-  return ioTask(
-    (world, resolve, ioError) => world.fs.readFile(path, options, toCallback(resolve, ioError))
-  )
+// Return a IO method equivalent of a node method of a certain module.
+const ioFunction = R.curry(function (moduleName, numberOfArgs, methodName) {
+  return R.curryN(numberOfArgs, function ioWrapper () {
+    const args = Array.prototype.slice.call(arguments)
+    return ioTask(
+      (world, resolve, ioError) => {
+        const callback = toCallback(resolve, ioError)
+        args.push(callback)
+        return world[moduleName][methodName].apply(null, args)
+      }
+    )
+  })
 })
 
-// readFile :: Object -> Path -> String|Buffer -> IO ()
-exports.writeFile = R.curry(function (options, path, data) {
-  return ioTask(
-    (world, resolve, ioError) => world.fs.writeFile(path, data, options, toCallback(resolve, ioError))
-  )
-})
-
-// stat :: Path -> IO Object
-exports.stat = R.curry(function (path) {
-  return ioTask(
-    (world, resolve, ioError) => world.fs.stat(path, toCallback(resolve, ioError))
-  )
-})
+exports.fs = R.mapObjIndexed(
+  ioFunction('fs'),
+  fsMethodLengths
+)
 
 function toCallback (resolve, ioError) {
   const callback = (error, result) => error ? ioError(error) : resolve(result)

--- a/test/test.js
+++ b/test/test.js
@@ -19,7 +19,7 @@ test('node.cwd', (t) => {
 test('node.argv', (t) => {
   const argv = ['/env/node']
   const fakeWorld = new FakeWorld().$setArgv(argv)
-  const io = node.argv()
+  const io = node.argv
   io
     .map((x) => {
       t.same(x, argv)
@@ -79,7 +79,7 @@ test('node.readFile', (t) => {
     t.same(_options, options)
     return callback(null, contents)
   })
-  const io = node.readFile(options, filePath)
+  const io = node.fs.readFile(filePath, options)
   io
     .map((x) => {
       t.same(x, contents)
@@ -98,7 +98,7 @@ test('node.writeFile', (t) => {
     t.equal(_contents, contents)
     return callback()
   })
-  const io = node.writeFile(options, filePath, contents)
+  const io = node.fs.writeFile(filePath, contents, options)
   io
     .map((x) => {
       t.end()
@@ -113,7 +113,7 @@ test('node.stat', (t) => {
     t.equal(_filePath, filePath)
     return callback(null, stat)
   })
-  const io = node.stat(filePath)
+  const io = node.fs.stat(filePath)
   io
     .map((x) => {
       t.same(x, stat)


### PR DESCRIPTION
Following the native API's brings two advantages:
- You don't need to learn a new API to use this library.
- It becomes possible to generate monadic versions of all the methods in
  a module on the fly (as demonstrated by the transformation of the fs
  module).
